### PR TITLE
Remove pypng dependency

### DIFF
--- a/viz_tools/array_to_png.py
+++ b/viz_tools/array_to_png.py
@@ -2,7 +2,7 @@
 
 import io
 # !pip install pypng
-import png
+#import png
 import numpy as np
 import PIL
 from IPython.display import Image, display
@@ -11,19 +11,17 @@ def get_png_from_array(data):
     """
     Take a 2D numpy array of 8-bit integer (I think?)
     values (rows x cols) and convert it
-    to a grayscale (1-channel) PNG. 
+    to a grayscale (1-channel) PNG in memory. 
     
     Returns a 1D list of values that can be passed to, for
     example, IPython.display.Image
     """
-    buf = io.BytesIO()
-    w = png.Writer(*data.shape[::-1], greyscale=True)
-    w.write(buf, data)
-    return buf.getvalue()
-
-def display_img_array(ima):
-    im = PIL.Image.fromarray(ima)
+    im = PIL.Image.fromarray(data)
     bio = io.BytesIO()
     im.convert('RGB')
     im.save(bio, format='png')
-    display(Image(bio.getvalue(), format='png', retina=True))
+    return img.getvalue()
+
+def display_img_array(ima):
+    bio=get_png_from_array(ima)
+    display(Image(bio, format='png', retina=True))

--- a/viz_tools/array_to_png.py
+++ b/viz_tools/array_to_png.py
@@ -20,7 +20,7 @@ def get_png_from_array(data):
     bio = io.BytesIO()
     im.convert('RGB')
     im.save(bio, format='png')
-    return img.getvalue()
+    return bio.getvalue()
 
 def display_img_array(ima):
     bio=get_png_from_array(ima)


### PR DESCRIPTION
Png dependency is obscure enough that using only PIL in array_to_png makes sense. 